### PR TITLE
Convert to using [NetworkAdapterInterface]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 #### Security
 
 
-## [0.0.12] - 2024-02-27
+## [1.1.1] - 2024-02-28
 #### Added
 - onData callback method (replacing the rxjs observable pattern from original implementation).
 - Export types from package.
+- Converted adapter to implement [NetworkAdapterInterface] as [NetworkAdapter] base abstract class deprecated.
 #### Changed
 - Rename `WebrtcNetworkAdapter` to `PeerjsNetworkAdapter`
+- Version set to `1.1.1` to match main `automerge-repo` version.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 #### Security
 
 
+## [Unreleased] - YYYY-MM-DD
+#### Added
+#### Changed
+- Rename `WebrtcNetworkAdapter` to `PeerjsNetworkAdapter`
+#### Deprecated
+#### Removed
+#### Fixed
+#### Security
+
+
 
 ## [0.0.1] - 2024-02-27
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 #### Security
 
 
-## [Unreleased] - YYYY-MM-DD
+## [0.0.12] - 2024-02-27
 #### Added
+- onData callback method (replacing the rxjs observable pattern from original implementation).
+- Export types from package.
 #### Changed
 - Rename `WebrtcNetworkAdapter` to `PeerjsNetworkAdapter`
-#### Deprecated
-#### Removed
-#### Fixed
-#### Security
 
 
 

--- a/README.md
+++ b/README.md
@@ -12,4 +12,5 @@ A network adapter for WebRTC, based on the point-to-point [MessageChannelNetwork
 yarn add automerge-repo-network-peerjs
 ```
 
-## Licence: MIT
+## Licence
+MIT

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![ci.node](https://github.com/philcockfield/automerge-repo-network-peerjs/actions/workflows/ci.node.yml/badge.svg)](https://github.com/philcockfield/automerge-repo-network-peerjs/actions/workflows/ci.node.yml)
 # automerge-repo-network-peerjs
+[![ci.node](https://github.com/philcockfield/automerge-repo-network-peerjs/actions/workflows/ci.node.yml/badge.svg)](https://github.com/philcockfield/automerge-repo-network-peerjs/actions/workflows/ci.node.yml) 
 
 A network adapter for WebRTC, based on the point-to-point [MessageChannelNetworkAdapter](https://github.com/automerge/automerge-repo/blob/main/packages/automerge-repo-network-messagechannel/src/index.ts).
 
@@ -11,6 +11,13 @@ A network adapter for WebRTC, based on the point-to-point [MessageChannelNetwork
 ```
 yarn add automerge-repo-network-peerjs
 ```
+
+## Usage
+
+```ts
+import { PeerjsNetworkAdapter } from 'automerge-repo-network-peerjs';
+```
+
 
 ## Licence
 MIT

--- a/README.md
+++ b/README.md
@@ -7,15 +7,35 @@ A network adapter for WebRTC, based on the point-to-point [MessageChannelNetwork
 **Please Note:** This is not an official part of the [automerge-repo](https://github.com/automerge/automerge-repo) project, rather a community contribution that includes a dependency on the [peerjs](https://github.com/peers/peerjs) library.
    
 ## Setup
-
 ```
 yarn add automerge-repo-network-peerjs
 ```
 
 ## Usage
 
+Establish a data connection as per [peerjs](https://github.com/peers/peerjs#data-connections) documentation:
+
+```ts
+import { Peer } from "peerjs";
+const conn = peer.connect("another-peers-id");
+```
+
+Then use that to pass into the constructor of the automerge network adapter:
+
 ```ts
 import { PeerjsNetworkAdapter } from 'automerge-repo-network-peerjs';
+const adapter = new PeerjsNetworkAdapter(conn);
+```
+
+Along with the usual `NetworkAdapterInterface` events an additional `onData` event is available to 
+to keep track of directional data being sent and received, for example:
+
+```ts
+function monitor(adapter: PeerjsNetworkAdapter, dispose$?: Observable<any>) {
+  const detach = adapter.onData((e) => console.log(`⚡️ ${e.direction}: ${e.bytes} bytes`));
+  dispose$?.subscribe(() => detach());
+}
+
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "automerge-repo-network-peerjs",
-  "version": "0.0.1",
+  "version": "0.0.12",
   "description": "Network adapter for automerge-repo using peerjs",
   "author": "phil Cockfield",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
     "test": "vitest"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "automerge-repo-network-peerjs",
-  "version": "0.0.12",
+  "version": "1.1.1",
   "description": "Network adapter for automerge-repo using peerjs",
   "author": "phil Cockfield",
   "license": "MIT",

--- a/src/NetworkAdapter.test.ts
+++ b/src/NetworkAdapter.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 describe("NetworkAdapter", () => {
+  /**
+   * NOTE: WebRTC is a browser based technology so server-side testing is hard.
+   *       Over time, if it becomes necessary, we can expand these tests out
+   *       to include mocking.
+   */
   it("placeholder", () => {
     expect(123).to.eql(123);
   });

--- a/src/NetworkAdapter.ts
+++ b/src/NetworkAdapter.ts
@@ -10,7 +10,7 @@ import type * as t from "./t.js";
  *    https://github.com/automerge/automerge-repo/blob/main/packages/automerge-repo-network-messagechannel/src/index.ts
  *
  */
-export class WebrtcNetworkAdapter extends NetworkAdapter {
+export class PeerjsNetworkAdapter extends NetworkAdapter {
   #conn: t.DataConnection;
   #isReady = false;
   #disconnected = new EventEmitter<"disconnected">();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { WebrtcNetworkAdapter } from "./NetworkAdapter.js";
+export { PeerjsNetworkAdapter } from "./NetworkAdapter.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { PeerjsNetworkAdapter } from "./NetworkAdapter.js";
+export type { NetworkMessage, NetworkMessageAlert } from "./types.js";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,22 @@
 /**
  * @automerge
  */
-import type { Message, PeerId, RepoMessage, StorageId } from "@automerge/automerge-repo";
-export { Message, PeerId, RepoMessage };
+import type {
+  Message,
+  NetworkAdapterEvents,
+  NetworkAdapterInterface,
+  PeerId,
+  RepoMessage,
+  StorageId,
+} from "@automerge/automerge-repo";
+export type {
+  Message,
+  NetworkAdapterEvents,
+  NetworkAdapterInterface,
+  PeerId,
+  RepoMessage,
+  StorageId,
+};
 
 /**
  * @peerjs
@@ -22,6 +36,7 @@ export type NetworkMessage = ArriveMessage | WelcomeMessage | Message;
 export type NetworkMessageAlert = {
   direction: IODirection;
   message: NetworkMessage;
+  bytes: number;
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,12 +15,13 @@ export type { DataConnection } from "peerjs";
  *    MessageChannelNetworkAdapter
  *    https://github.com/automerge/automerge-repo/blob/main/packages/automerge-repo-network-messagechannel/src/index.ts
  */
-export type IODirection = "incoming" | "outgoing";
+export type { PeerjsNetworkAdapter } from "./NetworkAdapter.js";
 
-export type WebrtcMessage = ArriveMessage | WelcomeMessage | Message;
-export type WebrtcMessageAlert = {
+export type IODirection = "incoming" | "outgoing";
+export type NetworkMessage = ArriveMessage | WelcomeMessage | Message;
+export type NetworkMessageAlert = {
   direction: IODirection;
-  message: WebrtcMessage;
+  message: NetworkMessage;
 };
 
 /**


### PR DESCRIPTION
The abstract base class `NetworkAdapter` has been deprecated. 
Now implements the `NetworkAdapterInterface` directly.

```ts
export class PeerjsNetworkAdapter
  extends EventEmitter<t.NetworkAdapterEvents>
  implements t.NetworkAdapterInterface

...

}
```